### PR TITLE
Link directly to detailurl

### DIFF
--- a/plugins/my-calendar/mc-custom-fields.php
+++ b/plugins/my-calendar/mc-custom-fields.php
@@ -24,6 +24,22 @@ function event_subheader( $form, $has_data, $event, $context ) {
 	return $form;
 }
 
+add_filter( 'mc_event_details', 'event_link_to_detailurl', 10, 4 );
+function event_link_to_detailurl( $form, $has_data, $event, $context ) {
+    if ( $has_data ) {
+        $post_id = $event->event_post;
+        /* Custom fields are stored as custom post meta */
+        $linked = esc_attr( get_post_meta( $post_id, '_mc_event_link_to_detailurl', true ) );
+    } else {
+        $linked = '';
+    }
+    $checked = $linked == true ? "checked" : "";
+    $form .= "<p><label for='event_subheader'>" . __( 'Link directly from calendar to detail url (ie Eventbrite)?' ) . "</label><input style='margin-left:5px;' from='my-calendar' name='event_link_to_detailurl' id='event_link_to_detailurl' type='checkbox' value='true' $checked/></input></p>";
+
+    return $form;
+}
+
+
 /**
  * Save custom fields into post meta.
  *
@@ -37,4 +53,11 @@ add_action( 'mc_update_event_post', 'my_event_subheader_save', 10, 4 );
 function my_event_subheader_save( $post_id, $post, $data, $event_id ) {
 	$subheader = trim($post['event_subheader']);
 	update_post_meta( $post_id, '_mc_event_subheader', $subheader );
+}
+
+add_action( 'mc_update_event_post', 'event_link_to_detailurl_save', 10, 4 );
+function event_link_to_detailurl_save( $post_id, $post, $data, $event_id ) {
+    $link_directly_str = trim($post['event_link_to_detailurl']);
+    $link_directly = $link_directly_str === 'true' ? true : false;
+    update_post_meta( $post_id, '_mc_event_link_to_detailurl', $link_directly );
 }

--- a/plugins/my-calendar/mc-custom-fields.php
+++ b/plugins/my-calendar/mc-custom-fields.php
@@ -23,18 +23,19 @@ function event_subheader( $form, $has_data, $event, $context ) {
 
 	return $form;
 }
-
-add_filter( 'mc_event_details', 'event_link_to_detailurl', 10, 4 );
-function event_link_to_detailurl( $form, $has_data, $event, $context ) {
+// add capability to link directly from calendar view into the specified event link (ie a Eventbrite link, etc)
+//   instead of to the details page that will live on the site
+add_filter( 'mc_event_details', 'event_links_to_eventlink', 10, 4 );
+function event_links_to_eventlink( $form, $has_data, $event, $context ) {
     if ( $has_data ) {
         $post_id = $event->event_post;
         /* Custom fields are stored as custom post meta */
-        $linked = esc_attr( get_post_meta( $post_id, '_mc_event_link_to_detailurl', true ) );
+        $linked = esc_attr( get_post_meta( $post_id, '_mc_event_links_to_eventlink', true ) );
     } else {
         $linked = '';
     }
     $checked = $linked == true ? "checked" : "";
-    $form .= "<p><label for='event_subheader'>" . __( 'Link directly from calendar to detail url (ie Eventbrite)?' ) . "</label><input style='margin-left:5px;' from='my-calendar' name='event_link_to_detailurl' id='event_link_to_detailurl' type='checkbox' value='true' $checked/></input></p>";
+    $form .= "<p><label for='event_subheader'>" . __( 'Link directly from calendar to event url (ie Eventbrite)?' ) . "</label><input style='margin-left:5px;' from='my-calendar' name='event_links_to_eventlink' id='event_links_to_eventlink' type='checkbox' value='true' $checked/></input></p>";
 
     return $form;
 }
@@ -55,9 +56,9 @@ function my_event_subheader_save( $post_id, $post, $data, $event_id ) {
 	update_post_meta( $post_id, '_mc_event_subheader', $subheader );
 }
 
-add_action( 'mc_update_event_post', 'event_link_to_detailurl_save', 10, 4 );
-function event_link_to_detailurl_save( $post_id, $post, $data, $event_id ) {
-    $link_directly_str = trim($post['event_link_to_detailurl']);
+add_action( 'mc_update_event_post', 'event_links_to_eventlink_save', 10, 4 );
+function event_links_to_eventlink_save( $post_id, $post, $data, $event_id ) {
+    $link_directly_str = trim($post['event_links_to_eventlink']);
     $link_directly = $link_directly_str === 'true' ? true : false;
-    update_post_meta( $post_id, '_mc_event_link_to_detailurl', $link_directly );
+    update_post_meta( $post_id, '_mc_event_links_to_eventlink', $link_directly );
 }

--- a/plugins/my-calendar/mc-custom-template.php
+++ b/plugins/my-calendar/mc-custom-template.php
@@ -134,10 +134,11 @@ function dont_exclude_events_in_search( $bool ) {
 //    return get_stylesheet_directory_uri() . '/js/my-calendar/mini-cal.js';
 //}
 
-//mc_customize_details_link
-add_filter('mc_customize_details_link', 'possibly_link_to_eventbrite', 10, 2);
-function possibly_link_to_eventbrite($details_link, $event) {
-    $use_direct_link = get_post_meta( $event->event_post, '_mc_event_link_to_detailurl', true );
+//possibly link to the direct event_link property instead of the details link that will route into a wordpress page.
+// allows for linking directly to eventbrite, etc
+add_filter('mc_customize_details_link', 'possibly_link_to_eventlink', 10, 2);
+function possibly_link_to_eventlink($details_link, $event) {
+    $use_direct_link = get_post_meta( $event->event_post, '_mc_event_links_to_eventlink', true );
     if ($use_direct_link == true) {
         return $event->event_link;
     }

--- a/plugins/my-calendar/mc-custom-template.php
+++ b/plugins/my-calendar/mc-custom-template.php
@@ -134,5 +134,14 @@ function dont_exclude_events_in_search( $bool ) {
 //    return get_stylesheet_directory_uri() . '/js/my-calendar/mini-cal.js';
 //}
 
+//mc_customize_details_link
+add_filter('mc_customize_details_link', 'possibly_link_to_eventbrite', 10, 2);
+function possibly_link_to_eventbrite($details_link, $event) {
+    $use_direct_link = get_post_meta( $event->event_post, '_mc_event_link_to_detailurl', true );
+    if ($use_direct_link == true) {
+        return $event->event_link;
+    }
+    return $details_link;
+}
 
 include 'mc-custom-fields.php';


### PR DESCRIPTION
[youtrack issue](https://ten-forward.myjetbrains.com/youtrack/agiles/113-2/114-16?issue=VERA-21)

optional field to bypass clicking from calendar to the event details page and instead go directly to the specified event url. allows for clicking in calendar to go straight to Eventbrite or whatever ticketing platform used. 